### PR TITLE
adds ord instance to set

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ instance showSet :: (Show a) => Show (Set a)
 ```
 
 
+#### `ordSet`
+
+``` purescript
+instance ordSet :: (Ord a) => Ord (Set a)
+```
+
+
 #### `empty`
 
 ``` purescript

--- a/src/Data/Set.purs
+++ b/src/Data/Set.purs
@@ -36,6 +36,9 @@ instance eqSet :: (Eq a) => Eq (Set a) where
 instance showSet :: (Show a) => Show (Set a) where
   show s = "fromList " ++ show (toList s)
 
+instance ordSet :: (Ord a) => Ord (Set a) where
+  compare s1 s2 = compare (toList s1) (toList s2)
+
 -- | An empty set
 empty :: forall a. Set a
 empty = Set M.empty


### PR DESCRIPTION
This behaves the same as Haskells implementation of Ord for set.

Fixes #10 