### PR TITLE
Fix a typo in the name of the semigroup instance, rerun docs

### DIFF
--- a/docs/Data/Set.md
+++ b/docs/Data/Set.md
@@ -19,7 +19,8 @@ instance eqSet :: (Eq a) => Eq (Set a)
 instance showSet :: (Show a) => Show (Set a)
 instance ordSet :: (Ord a) => Ord (Set a)
 instance monoidSet :: (Ord a) => Monoid (Set a)
-instance monoidSemigroup :: (Ord a) => Semigroup (Set a)
+instance semigroupSet :: (Ord a) => Semigroup (Set a)
+instance foldableSet :: Foldable Set
 ```
 
 #### `empty`
@@ -86,7 +87,7 @@ Delete a value from a set
 toList :: forall a. Set a -> List a
 ```
 
-Convert a set to an array
+Convert a set to a list
 
 #### `fromList`
 
@@ -94,7 +95,7 @@ Convert a set to an array
 fromList :: forall a. (Ord a) => List a -> Set a
 ```
 
-Create a set from an array of elements
+Create a set from a list of elements
 
 #### `size`
 

--- a/src/Data/Set.purs
+++ b/src/Data/Set.purs
@@ -46,7 +46,7 @@ instance ordSet :: (Ord a) => Ord (Set a) where
 instance monoidSet :: (Ord a) => Monoid (Set a) where
   mempty = empty
 
-instance monoidSemigroup :: (Ord a) => Semigroup (Set a) where
+instance semigroupSet :: (Ord a) => Semigroup (Set a) where
   append = union
 
 instance foldableSet :: Foldable Set where


### PR DESCRIPTION
Looks like there were a couple other things that needed a docs update too.